### PR TITLE
[Draft] Reorder wezterm color in the colorscheme

### DIFF
--- a/home/misterio/features/desktop/common/wayland-wm/wezterm.nix
+++ b/home/misterio/features/desktop/common/wayland-wm/wezterm.nix
@@ -9,33 +9,35 @@ in
     enable = true;
     colorSchemes = {
       "${colorscheme.slug}" = {
-        foreground = "#${colors.base05}";
+        foreground = "#${colors.base04}";
         background = "#${colors.base00}";
 
         ansi = [
+          "#${colors.base01}"
           "#${colors.base08}"
-          "#${colors.base09}"
-          "#${colors.base0A}"
           "#${colors.base0B}"
-          "#${colors.base0C}"
+          "#${colors.base0A}"
           "#${colors.base0D}"
-          "#${colors.base0E}"
           "#${colors.base0F}"
+          "#${colors.base0C}"
+          "#${colors.base06}"
         ];
         brights = [
           "#${colors.base00}"
-          "#${colors.base01}"
+          "#${colors.base09}"
           "#${colors.base02}"
           "#${colors.base03}"
           "#${colors.base04}"
+          "#${colors.base0E}"
           "#${colors.base05}"
-          "#${colors.base06}"
           "#${colors.base07}"
         ];
-        cursor_fg = "#${colors.base00}";
-        cursor_bg = "#${colors.base05}";
+
+        cursor_bg = "#${colors.base04}";
+        cursor_border = "#${colors.base04}";
+        cursor_fg = "#${colors.base01}";
         selection_fg = "#${colors.base00}";
-        selection_bg = "#${colors.base05}";
+        selection_bg = "#${colors.base01}";
       };
     };
     extraConfig = /* lua */ ''


### PR DESCRIPTION
The color in the colorscheme are in the bad order

You can see the result with `msgcat --color=test` before and after the reorder color (see the colorname and the color association)

**Before**
![2023-05-23_19-34](https://github.com/Misterio77/nix-config/assets/2806307/6d9371b4-b0ea-413e-ac51-ff11180c73a4)

**After**
![2023-05-23_19-35](https://github.com/Misterio77/nix-config/assets/2806307/74bd5bbd-7338-4ce5-8a66-356f6771998a)
